### PR TITLE
Prevent Checkout Steps Rendering When Checkout Is Null

### DIFF
--- a/src/components/Checkout/Steps.svelte
+++ b/src/components/Checkout/Steps.svelte
@@ -15,34 +15,55 @@
 
 <div class="px-6">
     <div class="relative">
-        <div class="bg-primary flex w-full items-center justify-between rounded-full border">
+        <div
+            class="w-full rounded-full"
+            style="height: 16px; background: var(--Variant-1, #E6E5F7);"
+        ></div>
+        <div
+            class="absolute top-0 left-0 rounded-full transition-all duration-500"
+            style="width: {((step - 1) / 3) *
+                100}%; height: 16px; background: var(--Primary, #59E9D3);"
+        ></div>
+
+        <div
+            class="absolute top-1/2 flex w-full -translate-y-1/2 items-center justify-between px-1"
+        >
             {#each [1, 2, 3, 4] as i}
                 <div
-                    class="h-4 w-4 rounded-full border-2 transition-all duration-300"
-                    class:bg-purple-900={i <= step}
-                    class:border-white={i <= step}
-                    class:bg-white={i > step}
-                    class:border-purple-900={i > step}
-                ></div>
+                    class="relative z-10 h-6 w-6 rounded-full border-2 bg-white transition-all duration-300"
+                    class:border-gray-300={i > step}
+                    style={i <= step
+                        ? "background: var(--Primary, #462949); border-color: var(--Primary, #462949);"
+                        : ""}
+                >
+                    {#if i <= step}
+                        <div class="absolute inset-0 flex items-center justify-center">
+                            <div class="h-2 w-2 rounded-full bg-white"></div>
+                        </div>
+                    {/if}
+                </div>
             {/each}
         </div>
     </div>
 
-    <div class="mt-2 flex w-full items-center justify-between text-sm font-bold text-gray-700">
+    <div class="mt-4 flex w-full items-center justify-between text-sm font-bold text-gray-700">
         {#each stepsLabels as label, index}
             <div
-                class={`flex items-center gap-1 ${
+                class={`flex max-w-[80px] items-center gap-1 text-center ${
                     step === index + 1 && hasError
-                        ? "text-[#E94668]"
-                        : step > index
-                          ? "text-purple-900"
-                          : ""
+                        ? "text-black"
+                        : step >= index + 1
+                          ? ""
+                          : "text-gray-400"
                 }`}
+                style={step >= index + 1 && !(step === index + 1 && hasError)
+                    ? "color: black;"
+                    : ""}
             >
                 {#if step === index + 1 && hasError}
-                    <WarningIcon className="w-5 h-5" />
+                    <WarningIcon className="w-4 h-4" />
                 {/if}
-                {label}
+                <span class="text-xs leading-tight">{label}</span>
             </div>
         {/each}
     </div>

--- a/src/components/Checkout/Steps.svelte
+++ b/src/components/Checkout/Steps.svelte
@@ -15,31 +15,24 @@
 
 <div class="px-6">
     <div class="relative">
-        <div
-            class="w-full rounded-full"
-            style="height: 16px; background: var(--Variant-1, #E6E5F7);"
-        ></div>
-        <div
-            class="absolute top-0 left-0 rounded-full transition-all duration-500"
-            style="width: {((step - 1) / 3) *
-                100}%; height: 16px; background: var(--Primary, #59E9D3);"
-        ></div>
+        <div class="w-full rounded-full h-4 bg-purple-tint"></div>
 
         <div
-            class="absolute top-1/2 flex w-full -translate-y-1/2 items-center justify-between px-1"
-        >
+            class="absolute top-0 left-0 rounded-full transition-all duration-500 h-4 bg-primary"
+            style="width: {((step - 1) / 3) * 100}%;"
+        ></div>
+
+        <div class="absolute top-1/2 flex w-full -translate-y-1/2 items-center justify-between px-1">
             {#each [1, 2, 3, 4] as i}
                 <div
-                    class="relative z-10 h-6 w-6 rounded-full border-2 bg-white transition-all duration-300"
-                    class:border-gray-300={i > step}
-                    style={i <= step
-                        ? "background: var(--Primary, #462949); border-color: var(--Primary, #462949);"
-                        : ""}
+                    class="relative z-10 h-4 w-4 rounded-full border-2 transition-all duration-300 flex items-center justify-center"
+                    class:bg-tertiary={i <= step}
+                    class:bg-purple-tint={i > step}
+                    class:border-primary={i <= step}
+                    class:border-black={i > step}
                 >
                     {#if i <= step}
-                        <div class="absolute inset-0 flex items-center justify-center">
-                            <div class="h-2 w-2 rounded-full bg-white"></div>
-                        </div>
+                        <div class="h-1.5 w-1.5 rounded-full bg-tertiary"></div>
                     {/if}
                 </div>
             {/each}
@@ -53,12 +46,9 @@
                     step === index + 1 && hasError
                         ? "text-black"
                         : step >= index + 1
-                          ? ""
+                          ? "text-black"
                           : "text-gray-400"
                 }`}
-                style={step >= index + 1 && !(step === index + 1 && hasError)
-                    ? "color: black;"
-                    : ""}
             >
                 {#if step === index + 1 && hasError}
                     <WarningIcon className="w-4 h-4" />

--- a/src/components/Checkout/Steps.svelte
+++ b/src/components/Checkout/Steps.svelte
@@ -15,24 +15,26 @@
 
 <div class="px-6">
     <div class="relative">
-        <div class="w-full rounded-full h-4 bg-purple-tint"></div>
+        <div class="bg-purple-tint h-4 w-full rounded-full"></div>
 
         <div
-            class="absolute top-0 left-0 rounded-full transition-all duration-500 h-4 bg-primary"
+            class="bg-primary absolute top-0 left-0 h-4 rounded-full transition-all duration-500"
             style="width: {((step - 1) / 3) * 100}%;"
         ></div>
 
-        <div class="absolute top-1/2 flex w-full -translate-y-1/2 items-center justify-between px-1">
+        <div
+            class="absolute top-1/2 flex w-full -translate-y-1/2 items-center justify-between px-1"
+        >
             {#each [1, 2, 3, 4] as i}
                 <div
-                    class="relative z-10 h-4 w-4 rounded-full border-2 transition-all duration-300 flex items-center justify-center"
+                    class="relative z-10 flex h-4 w-4 items-center justify-center rounded-full border-2 transition-all duration-300"
                     class:bg-tertiary={i <= step}
                     class:bg-purple-tint={i > step}
                     class:border-primary={i <= step}
                     class:border-black={i > step}
                 >
                     {#if i <= step}
-                        <div class="h-1.5 w-1.5 rounded-full bg-tertiary"></div>
+                        <div class="bg-tertiary h-1.5 w-1.5 rounded-full"></div>
                     {/if}
                 </div>
             {/each}


### PR DESCRIPTION
Fix an issue where the checkout steps were being rendered even when the checkout object was null. This ensures that the UI remains consistent and prevents potential errors.


<img width="710" height="418" alt="image" src="https://github.com/user-attachments/assets/1124f05b-7f16-4f7f-8ee9-19373f92be81" />

<img width="727" height="491" alt="image" src="https://github.com/user-attachments/assets/5f3c94c7-bce7-4a20-a31e-3a40e8bd5e69" />

