### PR TITLE
feat: remove Category translations

### DIFF
--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -5,6 +5,7 @@
     import { locale } from "../i18n/store";
     import Footer from "../layouts/Footer.svelte";
     import Header from "../layouts/Header.svelte";
+    import HeaderSubmenu from "../layouts/HeaderSubmenu.svelte";
 
     import type { Session } from "../auth/types";
     import type { Locale } from "../i18n/locales";
@@ -28,7 +29,9 @@
     });
 </script>
 
-<Header />
+<Header>
+    <HeaderSubmenu />
+</Header>
 <main
     class={twMerge(
         " mt-(--sticky-top) flex w-full max-w-screen flex-1 flex-col lg:max-h-none",

--- a/src/components/library/CategorySelect.svelte
+++ b/src/components/library/CategorySelect.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
-    import Category from "./Category.svelte";
+    import CategoryOption from "./Category.svelte";
 
-    export type Option = {
-        id: number | string;
-        text: string;
-    };
+    import type { Category } from "../../openapi/client";
 
     let {
         options,
@@ -14,19 +11,19 @@
         onchange,
         error = undefined,
     }: {
-        options: Option[];
-        selected?: Option[];
+        options: Category[];
+        selected?: Category[];
         selectedIds?: (number | string)[];
         max?: number;
-        onchange?: (selected: Option[], option: Option) => void;
+        onchange?: (selected: Category[], option: Category) => void;
         error?: string;
     } = $props();
 
-    function isSelected(option: Option): boolean {
+    function isSelected(option: Category): boolean {
         return selectedIds.includes(option.id);
     }
 
-    function handleClick(option: Option): void {
+    function handleClick(option: Category): void {
         if (isSelected(option)) {
             selectedIds = selectedIds.filter((id) => id !== option.id);
         } else {
@@ -38,7 +35,7 @@
         onchange?.(selected, option);
     }
 
-    function calcTagType(option: Option) {
+    function calcTagType(option: Category) {
         if (max === selectedIds.length) {
             return isSelected(option) ? "active" : "ghost";
         }
@@ -46,7 +43,7 @@
         return isSelected(option) ? "active" : "default";
     }
 
-    function calcTagDisabled(option: Option) {
+    function calcTagDisabled(option: Category) {
         if (max === selectedIds.length && !isSelected(option)) {
             return true;
         }
@@ -61,13 +58,13 @@
         aria-describedby={error ? "category-error" : undefined}
     >
         {#each options as option}
-            <Category
+            <CategoryOption
                 type={calcTagType(option)}
                 disabled={calcTagDisabled(option)}
                 onclick={() => handleClick(option)}
             >
-                {option.text}
-            </Category>
+                {option.name}
+            </CategoryOption>
         {/each}
     </fieldset>
     {#if error}

--- a/src/components/search/CategoryFilter.svelte
+++ b/src/components/search/CategoryFilter.svelte
@@ -4,9 +4,16 @@ Interactive category selection using existing categories from utils/categories.t
 Implements active/inactive pill states matching Figma design
 -->
 <script lang="ts">
-    import { t } from "../../i18n/store";
-    import { apiCategoriesGetCollection, type Category } from "../../openapi/client";
-    import CategorySelect, { type Option } from "../library/CategorySelect.svelte";
+    import { onMount } from "svelte";
+
+    import { locale, t } from "../../i18n/store";
+    import {
+        apiCategoriesGetCollection,
+        apiCategoriesIdGet,
+        type Category,
+    } from "../../openapi/client";
+    import { extractId } from "../../utils/extractId";
+    import CategorySelect from "../library/CategorySelect.svelte";
 
     interface Props {
         selectedCategories?: string[];
@@ -18,11 +25,11 @@ Implements active/inactive pill states matching Figma design
     let { selectedCategories = [], onCategoryChange, showLabel = true }: Props = $props();
 
     let categories = getAvailableCategories();
-    let selected = $state(
-        selectedCategories.map((s) => {
-            return { id: s, text: $t("domain.category." + s) };
-        }),
-    );
+    let selected = $state<Category[]>([]);
+
+    onMount(async () => {
+        selected = await Promise.all(selectedCategories.map((s) => getCategory(s)));
+    });
 
     async function getAvailableCategories(): Promise<Category[]> {
         const { data } = await apiCategoriesGetCollection();
@@ -34,17 +41,19 @@ Implements active/inactive pill states matching Figma design
         return data;
     }
 
-    function mapCategoryToOption(category: Category): Option {
-        return {
-            id: category.id!,
-            text: $t("domain.category." + category.id!),
-        };
+    async function getCategory(iri: string): Promise<Category> {
+        const { data: category } = await apiCategoriesIdGet({
+            headers: { "Accept-Language": $locale },
+            path: { id: extractId(iri)! },
+        });
+
+        return category!;
     }
 </script>
 
 <div class="w-full">
     {#if showLabel}
-        <h3 class="mb-6 font-['Karla'] text-base font-bold text-[#3d3d3d]">
+        <h3 class="mb-6 font-['Karla'] text-base font-bold text-black">
             {$t("pages.search.filters.categoryLabel")}
         </h3>
     {/if}
@@ -53,13 +62,13 @@ Implements active/inactive pill states matching Figma design
         <CategorySelect
             bind:selected
             selectedIds={selected.map((s) => s.id)}
-            options={categories.map((c) => mapCategoryToOption(c))}
+            options={categories}
             onchange={(selected) => onCategoryChange?.(selected.map((o) => `${o.id}`))}
         />
     {/await}
 
     {#if selected.length > 0}
-        <div class="mt-4 text-sm text-[#3d3d3d] opacity-70">
+        <div class="mt-4 text-sm text-black opacity-70">
             {$t("pages.search.filters.selectedCategories", { count: selected.length })}
         </div>
     {/if}

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -22,10 +22,14 @@
       "expired": "Campaña finalizada"
     },
     "login": "Iniciar Sesión",
-    "goHome": "Volver a inicio"
+    "goHome": "Volver a inicio",
+    "viewAll": "Ver todo"
   },
   "domain": {
     "_": "Business concepts (project, reward, contribution, etc.)",
+    "header": {
+      "categories": "Proyectos"
+    },
     "project": {
       "campaign": {
         "minimumReached": "¡Mínimo conseguido!",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -57,17 +57,6 @@
         "successful": "Exitosas",
         "completed": "Completadas"
       }
-    },
-    "category": {
-      "culture": "Cultura",
-      "rights": "Derechos",
-      "education": "Educación",
-      "journalism": "Periodismo independiente",
-      "health": "Salud",
-      "ecological_transition": "Transición ecológica",
-      "social_economy": "Economía social",
-      "rural": "Rural",
-      "science": "Ciencia"
     }
   },
   "pages": {

--- a/src/layouts/HeaderCategories.svelte
+++ b/src/layouts/HeaderCategories.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+    import { locale, t } from "../i18n/store";
+    import { apiCategoriesGetCollection, type Category } from "../openapi/client";
+
+    const MAX_ITEMS = 10;
+    const ITEMS_PER_COLUMN = 5;
+
+    async function getCategories(): Promise<Category[]> {
+        const { data: categories } = await apiCategoriesGetCollection({
+            headers: { "Accept-Language": $locale },
+        });
+
+        return categories ?? [];
+    }
+
+    function chunkArray<T>(array: T[], size: number): T[][] {
+        const chunks: T[][] = [];
+
+        for (let i = 0; i < array.length; i += size) {
+            chunks.push(array.slice(i, i + size));
+        }
+
+        return chunks;
+    }
+</script>
+
+{#await getCategories() then categories}
+    {@const hasMore = categories.length > MAX_ITEMS}
+
+    {@const visibleCategories = categories.slice(0, hasMore ? MAX_ITEMS - 1 : MAX_ITEMS)}
+
+    {@const items = hasMore
+        ? [...visibleCategories, { id: "_all", name: $t("common.viewAll") }]
+        : visibleCategories}
+
+    {@const columns = chunkArray(items, ITEMS_PER_COLUMN)}
+
+    <div class="flex gap-10">
+        {#each columns as column}
+            <ul class="space-y-3">
+                {#each column as category}
+                    <li>
+                        {#if category.id === "_all"}
+                            <a class="font-bold text-black" href="/search">
+                                {category.name} &gt;
+                            </a>
+                        {:else}
+                            <a
+                                class="font-bold text-black"
+                                href="/search?categories[]={category.id}"
+                            >
+                                {category.name}
+                            </a>
+                        {/if}
+                    </li>
+                {/each}
+            </ul>
+        {/each}
+    </div>
+{/await}

--- a/src/layouts/HeaderSubmenu.svelte
+++ b/src/layouts/HeaderSubmenu.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    import HeaderCategories from "./HeaderCategories.svelte";
+    import { t } from "../i18n/store";
+</script>
+
+<nav class="mt-5 mb-10 flex gap-20 px-2 md:px-6">
+    <section>
+        <h2 class="mb-4 text-3xl font-bold text-black">
+            {$t("domain.header.categories")}
+        </h2>
+
+        <HeaderCategories />
+    </section>
+</nav>

--- a/src/pages/[...locale]/create/CreateProjectForm.svelte
+++ b/src/pages/[...locale]/create/CreateProjectForm.svelte
@@ -71,7 +71,7 @@
         }
     });
 
-    function handleCategoryChange(selected: { id: number | string; text: string }[]) {
+    function handleCategoryChange(selected: Category[]) {
         const categoryIds = selected.map((s) => s.id.toString());
         handleFieldChange("categories", categoryIds);
     }
@@ -260,9 +260,7 @@
             </p>
             <CategorySelect
                 max={2}
-                options={categories.map((c) => {
-                    return { id: c.id!, text: c.name };
-                })}
+                options={categories}
                 onchange={handleCategoryChange}
                 error={shouldShowError("categories") ? $t($validationErrors.categories) : undefined}
             />

--- a/src/pages/[...locale]/create/project.astro
+++ b/src/pages/[...locale]/create/project.astro
@@ -6,7 +6,7 @@ import { apiCategoriesGetCollection } from "../../../openapi/client";
 
 const { t, lang, langs, session } = Astro.locals;
 
-if (session) {
+if (!session) {
     return Astro.redirect("/login");
 }
 


### PR DESCRIPTION
- [x] Removes translation keys of categories, they come from the API now
- [x] Simplify category-based components to use type from SDK and name for display
- [x] Added available categories list in header submenu