### PR TITLE
fix: skip "all" status filter in project search API call

### DIFF
--- a/src/services/projectsService.ts
+++ b/src/services/projectsService.ts
@@ -26,9 +26,11 @@ export class ProjectsService {
         hasNextPage: boolean;
     }> {
         try {
+            const { status, ...restFilters } = filters ?? {};
             const response = await apiProjectsGetCollection({
                 query: {
-                    ...filters,
+                    ...restFilters,
+                    ...(status && status !== "all" && { status }),
                     page: options?.page || 1,
                     itemsPerPage: options?.limit || 20,
                 },


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215413814209870