### PR TITLE
[fix] bypass browser cache interceptor on direct read operations in admin projects page

### DIFF
--- a/src/components/admin/Projects.svelte
+++ b/src/components/admin/Projects.svelte
@@ -5,6 +5,7 @@
     import ProjectsTable from "./ProjectsTable.svelte";
     import Slider from "./Slider.svelte";
     import { t } from "../../i18n/store";
+    import { withoutCache } from "../../openapi/cacheInterceptor";
     import {
         apiProjectsGetCollection,
         apiProjectsIdPatch,
@@ -89,23 +90,27 @@
             : ((record["hydra:member"] as unknown[])?.length ?? 0);
     }
 
-    async function loadProjects(): Promise<void> {
+    async function loadProjects(bypassCache = false): Promise<void> {
         isLoading = true;
 
-        try {
+        async function fetchProjects() {
             const query = buildProjectsQuery(filters, currentPage, itemsPerPage, selectedSort);
 
-            const {
-                data: collection,
-                response,
-                error,
-            } = await apiProjectsGetCollection({
+            return apiProjectsGetCollection({
                 query,
                 headers: {
                     Accept: "application/ld+json",
                     "Accept-Language": " ",
                 },
             });
+        }
+
+        try {
+            const {
+                data: collection,
+                response,
+                error,
+            } = await (bypassCache ? withoutCache(fetchProjects) : fetchProjects());
 
             if (error) {
                 console.error("Failed to fetch projects:", error);
@@ -194,7 +199,7 @@
         }
     }
 
-    function reloadProjects(): void {
+    function reloadProjects(bypassCache = false): void {
         const queryKey = JSON.stringify({ filters, selectedSort, itemsPerPage });
         if (queryKey !== lastQueryKey) {
             accountingsCache = new Map();
@@ -202,7 +207,7 @@
             lastQueryKey = queryKey;
         }
         projectRows = [];
-        loadProjects();
+        loadProjects(bypassCache);
     }
 
     $effect(() => {
@@ -234,6 +239,9 @@
         if (value.length >= 4 || value.length === 0) {
             if (value) {
                 filters = { ...filters, title: value };
+                currentPage = 1;
+                reloadProjects(true);
+                return;
             } else {
                 const { ...rest } = filters;
                 filters = rest;

--- a/src/components/admin/ProjectsTable.svelte
+++ b/src/components/admin/ProjectsTable.svelte
@@ -37,6 +37,7 @@
     import ProjectsModalAnnotations from "./ProjectsModalAnnotations.svelte";
     import ProjectsModalPaid from "./ProjectsModalPaid.svelte";
     import { t } from "../../i18n/store";
+    import { withoutCache } from "../../openapi/cacheInterceptor";
     import { apiUsersIdOrHandleGet, type User } from "../../openapi/client/index.ts";
     import { extractId } from "../../utils/extractId";
     import Edit from "../icons/actions/Edit.svelte";
@@ -147,7 +148,9 @@
             if (!ownerUsers.has(ownerIri)) {
                 const userId = extractId(ownerIri);
                 if (userId) {
-                    apiUsersIdOrHandleGet({ path: { idOrHandle: userId } }).then(({ data }) => {
+                    withoutCache(() =>
+                        apiUsersIdOrHandleGet({ path: { idOrHandle: userId } }),
+                    ).then(({ data }) => {
                         if (data) {
                             ownerUsers = new Map(ownerUsers).set(ownerIri, data as User);
                         }

--- a/src/layouts/App.svelte
+++ b/src/layouts/App.svelte
@@ -8,7 +8,7 @@
     import HeaderSubmenu from "./HeaderSubmenu.svelte";
     import { session } from "../auth/store";
     import { locale } from "../i18n/store";
-    import { createBrowserCacheInterceptor } from "../openapi/cacheFetch";
+    import { initCacheInterceptor } from "../openapi/cacheInterceptor";
     import { client } from "../openapi/client/client.gen";
 
     import type { Session } from "../auth/types";
@@ -41,7 +41,7 @@
             return request;
         });
 
-        client.interceptors.request.use(createBrowserCacheInterceptor());
+        initCacheInterceptor();
     });
 
     $effect(() => {

--- a/src/openapi/cacheInterceptor.ts
+++ b/src/openapi/cacheInterceptor.ts
@@ -1,0 +1,30 @@
+import { client } from "./client/client.gen";
+import { createBrowserCacheInterceptor } from "./cacheFetch";
+
+let _interceptor: ReturnType<typeof createBrowserCacheInterceptor> | null = null;
+let _interceptorId: number | null = null;
+
+export function getCacheInterceptor() {
+  return _interceptor;
+}
+
+export function getCacheInterceptorId() {
+  return _interceptorId;
+}
+
+export function initCacheInterceptor() {
+  _interceptor = createBrowserCacheInterceptor();
+  _interceptorId = client.interceptors.request.use(_interceptor);
+  return _interceptorId;
+}
+
+export async function withoutCache<T>(fn: () => Promise<T>): Promise<T> {
+  if (!_interceptor) return fn();
+  
+  client.interceptors.request.eject(_interceptor);
+  try {
+    return await fn();
+  } finally {
+    client.interceptors.request.use(_interceptor);
+  }
+}

--- a/src/openapi/cacheInterceptor.ts
+++ b/src/openapi/cacheInterceptor.ts
@@ -5,26 +5,26 @@ let _interceptor: ReturnType<typeof createBrowserCacheInterceptor> | null = null
 let _interceptorId: number | null = null;
 
 export function getCacheInterceptor() {
-  return _interceptor;
+    return _interceptor;
 }
 
 export function getCacheInterceptorId() {
-  return _interceptorId;
+    return _interceptorId;
 }
 
 export function initCacheInterceptor() {
-  _interceptor = createBrowserCacheInterceptor();
-  _interceptorId = client.interceptors.request.use(_interceptor);
-  return _interceptorId;
+    _interceptor = createBrowserCacheInterceptor();
+    _interceptorId = client.interceptors.request.use(_interceptor);
+    return _interceptorId;
 }
 
 export async function withoutCache<T>(fn: () => Promise<T>): Promise<T> {
-  if (!_interceptor) return fn();
-  
-  client.interceptors.request.eject(_interceptor);
-  try {
-    return await fn();
-  } finally {
-    client.interceptors.request.use(_interceptor);
-  }
+    if (!_interceptor) return fn();
+
+    client.interceptors.request.eject(_interceptor);
+    try {
+        return await fn();
+    } finally {
+        client.interceptors.request.use(_interceptor);
+    }
 }


### PR DESCRIPTION
## Summary

The browser cache interceptor was applied globally to all GET requests, including direct read operations where users expect fresh data (search by name, expanding project cards). This PR extracts the interceptor lifecycle into a shared module and adds a `withoutCache()` helper to bypass the cache for specific direct-read operations on the admin projects page.

## Behaviour

| Operation | Cache |
|---|---|
| General project list load | Cached |
| Search by project name | Bypassed |
| Expand project row (owner fetch) | Bypassed |


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215921687904493