### PR TITLE
[feat] Reusable Title library component

### DIFF
--- a/src/components/about/Table.svelte
+++ b/src/components/about/Table.svelte
@@ -164,7 +164,9 @@
     </svg>
 
     {#if title}
-        <h2 class="text-secondary text-center text-2xl font-bold lg:text-3xl">{title}</h2>
+        <Title level={2} variant="subsection" color="secondary" align="center">
+            {title}
+        </Title>
     {/if}
     <div class="grid gap-4" style="grid-template-columns: repeat({cols}, minmax(0, 1fr));">
         {@render children?.()}

--- a/src/components/admin/FiltersTags.svelte
+++ b/src/components/admin/FiltersTags.svelte
@@ -6,6 +6,7 @@
     import { getAllFilterSubjects } from "../../utils/filterComposer";
     import CloseIcon from "../icons/navigation/Close.svelte";
     import Tag from "../library/tags/Tag.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { Locale } from "../../i18n/locales";
     import type { Accounting, User, Project, Tipjar } from "../../openapi/client/index.ts";
@@ -217,9 +218,9 @@
 </script>
 
 <div class="flex gap-4">
-    <h1 class="text-2xl/8 font-bold text-black">
+    <Title level={1} variant="subsection">
         {title}
-    </h1>
+    </Title>
 
     {#each tags as tag}
         <Tag variant="bold">

--- a/src/components/admin/Search.svelte
+++ b/src/components/admin/Search.svelte
@@ -10,6 +10,8 @@
     import CloseIcon from "../icons/navigation/Close.svelte";
     import Spinner from "../icons/status/Spinner.svelte";
 
+    import SearchCategoryLabel from "./SearchCategoryLabel.svelte";
+
     import type { ProjectJsonld, TipjarJsonld, UserJsonld } from "../../openapi/client/index";
 
     type ResultItem =
@@ -153,7 +155,7 @@
                     handleInput(e.target instanceof HTMLInputElement ? e.target.value : "")}
                 placeholder={searchPlaceholder ??
                     $t("pages.admin.charges.filters.search.placeholder")}
-                class="border-secondary w-full rounded-3xl border p-4"
+                class="border-secondary w-full rounded-3xl border p-4 focus:ring-0"
                 minlength="4"
             />
             {#if query}
@@ -200,9 +202,9 @@
 
                 {#if results.some((r) => r.type === "project")}
                     <div>
-                        <h3 class="mb-2 text-sm font-bold text-gray-700 uppercase">
+                        <SearchCategoryLabel class="mb-2">
                             {$t("domain.charges.entityLabels.projects")}
-                        </h3>
+                        </SearchCategoryLabel>
                         <div class="flex flex-col gap-2">
                             {#each results.filter((r) => r.type === "project") as item}
                                 <button
@@ -237,9 +239,9 @@
 
                 {#if results.some((r) => r.type === "tipjar")}
                     <div>
-                        <h3 class="mt-6 mb-2 text-sm font-bold text-gray-700 uppercase">
+                        <SearchCategoryLabel class="mt-6 mb-2">
                             {$t("domain.charges.entityLabels.tipjars")}
-                        </h3>
+                        </SearchCategoryLabel>
                         <div class="flex flex-col gap-2">
                             {#each results.filter((r) => r.type === "tipjar") as item}
                                 <button
@@ -271,9 +273,9 @@
 
                 {#if results.some((r) => r.type === "user")}
                     <div>
-                        <h3 class="mt-6 mb-2 text-sm font-bold text-gray-700 uppercase">
+                        <SearchCategoryLabel class="mt-6 mb-2">
                             {$t("domain.charges.entityLabels.users")}
-                        </h3>
+                        </SearchCategoryLabel>
                         <div class="flex flex-col gap-2">
                             {#each results.filter((r) => r.type === "user") as item}
                                 <button

--- a/src/components/admin/SearchCategoryLabel.svelte
+++ b/src/components/admin/SearchCategoryLabel.svelte
@@ -1,0 +1,20 @@
+<!--
+    @component
+    Category label used in the admin search panel to group results by type
+    (Projects, Tipjars, Users).
+-->
+<script lang="ts">
+    import type { Snippet } from "svelte";
+    import { twMerge, type ClassNameValue } from "tailwind-merge";
+
+    interface Props {
+        children: Snippet;
+        class?: ClassNameValue;
+    }
+
+    let { children, class: classes = "" }: Props = $props();
+</script>
+
+<p class={twMerge("text-sm font-bold text-gray-700 uppercase", classes)}>
+    {@render children()}
+</p>

--- a/src/components/auth/AuthSummary.svelte
+++ b/src/components/auth/AuthSummary.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { t } from "../../i18n/store";
     import CollapsibleBox from "../library/layout/CollapsibleBox.svelte";
+    import Title from "../library/typography/Title.svelte";
 </script>
 
 <div class="flex items-start justify-between px-0 pt-0 pb-0 lg:hidden">
@@ -11,18 +12,18 @@
         buttonTextHide={$t("pages.checkout.summary.hide")}
     >
         {#snippet header()}
-            <h2 class="text-secondary flex items-center gap-2 text-base font-semibold">
+            <Title level={2} variant="subsection" color="secondary" class="flex items-center gap-2">
                 {$t("pages.login.page.welcome.title")}
-            </h2>
+            </Title>
         {/snippet}
     </CollapsibleBox>
 </div>
 
 <div class="hidden flex-col gap-6 pt-6 pb-0 lg:flex">
     <div>
-        <h2 class="text-secondary text-[3.5rem] leading-tight font-semibold">
+        <Title level={2} variant="display" color="secondary" weight="bold" class="leading-tight">
             {$t("pages.login.page.welcome.title")}
-        </h2>
+        </Title>
         <p class="text-content font-light">
             {$t("pages.login.page.welcome.subtitle")}
         </p>

--- a/src/components/checkout/Cart.svelte
+++ b/src/components/checkout/Cart.svelte
@@ -3,6 +3,7 @@
     import Tipjar from "./Tipjar.svelte";
     import { cart, cartByRecipient } from "../../stores/checkoutsStore";
     import * as tipping from "../../utils/tipping";
+    import Title from "../library/typography/Title.svelte";
 
     function increment(item: { key: string; quantity: number }) {
         cart.updateQuantity(item.key, item.quantity + 1);
@@ -32,9 +33,9 @@
 <div class="flex flex-col gap-10">
     {#each getItems() as [target, items]}
         <div class="flex flex-col gap-6">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {items[0].recipientDisplayName}
-            </h2>
+            </Title>
 
             {#each items as item (item.key)}
                 <CartItem

--- a/src/components/checkout/FeedbackForm.svelte
+++ b/src/components/checkout/FeedbackForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { t } from "../../i18n/store";
     import RadioButton from "../library/inputs/RadioButton.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     interface Props {
         paymentMethod?: string;
@@ -17,9 +18,9 @@
         <form id="feedback" method="POST" class="flex flex-col gap-4">
             <div class="flex flex-col gap-4">
                 <div class="flex flex-row items-center gap-2">
-                    <h2 class="text-2xl font-bold text-black">
+                    <Title level={2} variant="subsection">
                         {$t("pages.checkout.verify.approved.formGoal.title")}
-                    </h2>
+                    </Title>
                 </div>
             </div>
             <fieldset class="flex flex-col gap-6">
@@ -35,9 +36,9 @@
 
             <div class="mt-6 flex flex-col gap-4">
                 <div class="flex flex-row items-center gap-2">
-                    <h2 class="text-2xl font-bold text-black">
+                    <Title level={2} variant="subsection">
                         {$t("pages.checkout.verify.approved.formReview.title")}
-                    </h2>
+                    </Title>
                 </div>
                 <p class="text-content">
                     {$t("pages.checkout.verify.approved.formReview.description")}

--- a/src/components/checkout/Summary.svelte
+++ b/src/components/checkout/Summary.svelte
@@ -6,6 +6,7 @@
     import { multiplyMoney, sumMoney } from "../../utils/money";
     import CollapsibleBox from "../library/layout/CollapsibleBox.svelte";
     import Thtml from "../library/typography/Thtml.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     let { hasError = false }: { hasError?: boolean } = $props();
 
@@ -26,8 +27,12 @@
         buttonTextHide={$t("pages.checkout.summary.hideDetails")}
     >
         {#snippet header()}
-            <h2
-                class={`lg:text-double flex items-center gap-2 text-base font-semibold ${hasError ? "text-tertiary" : "text-secondary"}`}
+            <Title
+                level={2}
+                variant="subsection"
+                color={hasError ? "default" : "secondary"}
+                class={`flex items-center gap-2 ${hasError ? "text-tertiary lg:text-double" : "lg:text-double"}`}
+                weight="semibold"
             >
                 {#if hasError}
                     <span class="h-6 w-6">
@@ -35,7 +40,7 @@
                     </span>
                 {/if}
                 {$t("pages.checkout.summary.total.title")}
-            </h2>
+            </Title>
             <p
                 class={`text-double leading-tight font-bold lg:text-[3.5rem] ${hasError ? "text-tertiary" : "text-secondary"}`}
             >

--- a/src/components/checkout/Tipjar.svelte
+++ b/src/components/checkout/Tipjar.svelte
@@ -6,6 +6,7 @@
     import { cart, cartByRecipient, type CheckoutItem } from "../../stores/checkoutsStore";
     import { getUnit } from "../../utils/currencies";
     import * as tipping from "../../utils/tipping";
+    import Title from "../library/typography/Title.svelte";
 
     let amount = $state(tipping.defaultAmount / getUnit());
     let hasError = $state(false);
@@ -78,9 +79,9 @@
 
 <div class="flex w-auto flex-col gap-4">
     <div class="flex flex-col gap-2">
-        <h2 class="text-2xl font-bold text-black">
+        <Title level={2} variant="subsection">
             {$t("pages.checkout.tipjar.community")}
-        </h2>
+        </Title>
 
         <input
             class="w-full rounded border border-gray-300 p-2

--- a/src/components/create/CreateProjectForm.svelte
+++ b/src/components/create/CreateProjectForm.svelte
@@ -28,6 +28,7 @@
     } from "../../stores/drafts/projectDraft";
     import { maxEndDate } from "../../utils/campaign";
     import { getDefaultCurrency } from "../../utils/consts";
+    import Title from "../library/typography/Title.svelte";
     import { formatCurrency } from "../../utils/currencies";
     import Button from "../library/buttons/Button.svelte";
     import BaseCard from "../library/cards/BaseCard.svelte";
@@ -250,9 +251,9 @@
 <section class="wrapper md:flex md:flex-row">
     <div class="mb-20 flex max-w-167 flex-col gap-10">
         <div class="flex flex-col gap-4">
-            <h1 class="text-3xl font-bold text-black lg:text-4xl">
+            <Title level={1} variant="section">
                 {$t("pages.project.create.title")}
-            </h1>
+            </Title>
             <p class="text-black transition-all duration-300 ease-in-out">
                 {$t("pages.project.create.subtitle")}
             </p>
@@ -263,9 +264,9 @@
                 aria-live="polite"
                 class="rounded-md border-l-4 border-red-500 bg-red-50 p-4"
             >
-                <h2 class="mb-2 text-lg font-semibold text-red-800">
+                <p class="mb-2 text-lg font-semibold text-red-800">
                     {$t("system.validation.errors.summary.title")}
-                </h2>
+                </p>
                 <ul class="list-inside list-disc space-y-1">
                     {#each Object.entries($validationErrors) as [field, error]}
                         <li class="text-sm text-red-700">
@@ -292,9 +293,9 @@
             </div>
         {/if}
         <div class="flex flex-col gap-4">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.create.description.title")}
-            </h2>
+            </Title>
             <p class="text-black transition-all duration-300 ease-in-out">
                 {$t("pages.project.create.description.subtitle")}
             </p>
@@ -331,9 +332,9 @@
             </div>
         </div>
         <div class="flex flex-col gap-4">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.create.categories.title")}
-            </h2>
+            </Title>
             <p class="text-black transition-all duration-300 ease-in-out">
                 {$t("pages.project.create.categories.subtitle")}
             </p>
@@ -345,9 +346,9 @@
             />
         </div>
         <div class="flex flex-col gap-4">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.create.address.title")}
-            </h2>
+            </Title>
             <p class="text-black transition-all duration-300 ease-in-out">
                 {$t("pages.project.create.address.subtitle")}
             </p>
@@ -364,9 +365,9 @@
             />
         </div>
         <div class="flex flex-col gap-4">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.create.release.title")}
-            </h2>
+            </Title>
             <p class="text-black transition-all duration-300 ease-in-out">
                 {$t("pages.project.create.release.subtitle")}
             </p>
@@ -405,13 +406,15 @@
             class="border-grey flex h-full max-h-126.5 w-full max-w-109.25 flex-col bg-white"
             style="box-shadow: 0 35px 10px 0 rgba(0, 0, 0, 0.00), 0 22px 9px 0 rgba(0, 0, 0, 0.01), 0 13px 8px 0 rgba(0, 0, 0, 0.05), 0 6px 6px 0 rgba(0, 0, 0, 0.09), 0 1px 3px 0 rgba(0, 0, 0, 0.10);"
         >
-            <h1
-                class="text-secondary text-double mb-2 leading-10 font-bold {$currentDraft
-                    ?.createProject.title || 'opacity-24'}"
+            <Title
+                level={2}
+                variant="section"
+                color="secondary"
+                class="mb-2 {!$currentDraft?.createProject.title ? 'opacity-24' : ''}"
             >
                 {$currentDraft?.createProject.title ||
                     $t("pages.project.create.description.titlePlaceholder")}
-            </h1>
+            </Title>
             <p
                 class="text-content overflow-hidden text-base font-normal text-ellipsis whitespace-nowrap"
             >

--- a/src/components/errorpage/ErrorPage.svelte
+++ b/src/components/errorpage/ErrorPage.svelte
@@ -29,9 +29,9 @@
             {@render children?.()}
         </div>
         <div class="flex flex-col gap-4">
-            <h1 class="text-center text-3xl leading-tight font-bold text-black sm:text-6xl">
+            <Title level={1} variant="display" align="center">
                 {title}
-            </h1>
+            </Title>
             <p class="text-content text-center text-sm sm:text-base">
                 {subtitle}
             </p>

--- a/src/components/home/CampaignCard.svelte
+++ b/src/components/home/CampaignCard.svelte
@@ -14,6 +14,7 @@ Converted from CampaignCard.astro to maintain exact functionality
     import CampaignStatusBadge from "../home/CampaignStatusBadge.svelte";
     import Flames from "../icons/status/Flames.svelte";
     import Tag from "../library/tags/Tag.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { Accounting, Money } from "../../openapi/client";
     import type { Campaign, CampaignSize } from "../../types/campaign";
@@ -156,9 +157,14 @@ Converted from CampaignCard.astro to maintain exact functionality
                 </div>
 
                 <!-- Title -->
-                <h3 class="text-secondary h-16 overflow-hidden text-2xl leading-8 font-bold">
+                <Title
+                    level={3}
+                    variant="subsection"
+                    color="secondary"
+                    class="h-16 overflow-hidden leading-8"
+                >
                     {campaign.title}
-                </h3>
+                </Title>
 
                 <!-- Funding Information -->
                 <div class="flex flex-col gap-2">

--- a/src/components/home/HomeBanner.svelte
+++ b/src/components/home/HomeBanner.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import Close from "../icons/navigation/Close.svelte";
     import Button from "../library/buttons/Button.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     interface Props {
         title: string;
@@ -45,9 +46,9 @@
             class="relative z-10 flex flex-col gap-4 md:flex-row md:items-center md:justify-between"
         >
             <div class="flex-1 space-y-3">
-                <h2 class="text-2xl font-bold tracking-tight sm:text-3xl md:text-4xl">
+                <Title level={2} variant="section" class="tracking-tight">
                     {title}
-                </h2>
+                </Title>
                 <p class="text-variant1 max-w-3xl text-sm opacity-90 sm:text-base md:text-lg">
                     {description}
                 </p>

--- a/src/components/home/Stories.svelte
+++ b/src/components/home/Stories.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { t } from "../../i18n/store";
+    import Title from "../library/typography/Title.svelte";
 </script>
 
 <section class="wrapper py-16">
@@ -11,16 +12,23 @@
             <!-- Text Content -->
             <div class="flex min-h-87 max-w-132.25 flex-col gap-4">
                 <!-- Main Headline -->
-                <h2
-                    class="text-secondary text-2xl leading-tight font-bold md:text-[2.5rem] md:leading-12"
+                <Title
+                    level={2}
+                    variant="section"
+                    color="secondary"
+                    class="leading-tight"
                 >
                     {$t("pages.home.stories.title")}
-                </h2>
+                </Title>
 
                 <!-- Subtitle -->
-                <h3 class="text-secondary text-lg leading-8 font-bold md:text-2xl md:leading-8">
+                <Title
+                    level={3}
+                    variant="subsection"
+                    color="secondary"
+                >
                     {$t("pages.home.stories.subtitle")}
-                </h3>
+                </Title>
 
                 <!-- Description -->
                 <div class="text-content flex-1 text-sm leading-6 md:text-base md:leading-6">

--- a/src/components/library/typography/Title.stories.svelte
+++ b/src/components/library/typography/Title.stories.svelte
@@ -1,0 +1,82 @@
+<script module>
+    import { defineMeta } from "@storybook/addon-svelte-csf";
+
+    import Title from "./Title.svelte";
+
+    const { Story } = defineMeta({
+        component: Title,
+        title: "Library/Title",
+        tags: ["autodocs"],
+    });
+</script>
+
+<Story name="Display">
+    <Title level={1} variant="display">Display 56px</Title>
+</Story>
+
+<Story name="DisplayBold">
+    <Title level={1} variant="display" weight="bold">Display 56px Bold</Title>
+</Story>
+
+<Story name="Headline">
+    <Title level={2} variant="headline">Headline 40px</Title>
+</Story>
+
+<Story name="HeadlineBold">
+    <Title level={2} variant="headline" weight="bold">Headline 40px Bold</Title>
+</Story>
+
+<Story name="Section">
+    <Title level={2} variant="section">Section 32px</Title>
+</Story>
+
+<Story name="Subsection">
+    <Title level={3} variant="subsection">Subsection 24px</Title>
+</Story>
+
+<Story name="Field">
+    <Title level={3} variant="field">Field 16px</Title>
+</Story>
+
+<Story name="SecondaryColor">
+    <Title level={2} variant="headline" color="secondary">Headline purple</Title>
+</Story>
+
+<Story name="WhiteColorOnDark">
+    <div class="bg-secondary rounded p-6">
+        <Title level={3} variant="section" color="white">White on dark</Title>
+    </div>
+</Story>
+
+<Story name="PurpleSoft">
+    <Title level={4} variant="field" color="purple-soft">Footer column header</Title>
+</Story>
+
+<Story name="Truncate1">
+    <div class="w-64">
+        <Title level={3} variant="subsection" color="secondary" truncate={1}>
+            A very long card title that will be cut off after one line
+        </Title>
+    </div>
+</Story>
+
+<Story name="Truncate2">
+    <div class="w-64">
+        <Title level={3} variant="subsection" color="secondary" truncate={2}>
+            A very long card title that will be cut off after two lines so we can see how the
+            line-clamp utility works inside a constrained width container
+        </Title>
+    </div>
+</Story>
+
+<Story name="Uppercase">
+    <Title level={3} variant="subsection" uppercase>Uppercased section</Title>
+</Story>
+
+<Story name="Centered">
+    <Title level={2} variant="section" color="secondary" align="center">Centered title</Title>
+</Story>
+
+<Story name="CustomClass">
+    <Title level={1} variant="section" class="underline decoration-wavy">Custom override</Title>
+</Story>

--- a/src/components/library/typography/Title.svelte
+++ b/src/components/library/typography/Title.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+    import { twMerge, type ClassNameValue } from "tailwind-merge";
+
+    import type { Snippet } from "svelte";
+
+    export type TitleLevel = 1 | 2 | 3 | 4 | 5 | 6;
+    export type TitleVariant = "display" | "headline" | "section" | "subsection" | "field";
+    export type TitleWeight = "medium" | "bold" | "semibold" | "normal";
+    export type TitleColor = "default" | "secondary" | "white" | "purple-soft";
+    export type TitleAlign = "left" | "center" | "right";
+
+    export const SIZES: Record<TitleVariant, string> = {
+        display: "text-4xl leading-10 sm:text-5xl sm:leading-[3rem] md:text-[56px] md:leading-16",
+        headline: "text-3xl leading-9 sm:text-4xl sm:leading-11 md:text-[40px] md:leading-12",
+        section: "text-2xl leading-8 sm:text-3xl sm:leading-10 md:text-double md:leading-10",
+        subsection: "text-xl leading-7 sm:text-2xl sm:leading-8",
+        field: "text-sm leading-6 sm:text-base sm:leading-7",
+    };
+
+    const DEFAULT_WEIGHTS: Record<TitleVariant, TitleWeight> = {
+        display: "medium",
+        headline: "medium",
+        section: "medium",
+        subsection: "bold",
+        field: "bold",
+    };
+
+    const COLORS: Record<TitleColor, string> = {
+        default: "text-black",
+        secondary: "text-secondary",
+        white: "text-white",
+        "purple-soft": "text-purple-soft",
+    };
+
+    interface Props {
+        children: Snippet;
+        level: TitleLevel;
+        variant: TitleVariant;
+        weight?: TitleWeight;
+        color?: TitleColor;
+        truncate?: 0 | 1 | 2 | 3;
+        uppercase?: boolean;
+        align?: TitleAlign;
+        class?: ClassNameValue;
+    }
+
+    let {
+        children,
+        level,
+        variant,
+        weight,
+        color = "default",
+        truncate = 0,
+        uppercase = false,
+        align = "left",
+        class: classes = "",
+    }: Props = $props();
+
+    const effectiveWeight = $derived(weight ?? DEFAULT_WEIGHTS[variant]);
+    const weightClass = $derived(`font-${effectiveWeight}`);
+
+    const classFinal = $derived(
+        twMerge(
+            SIZES[variant],
+            weightClass,
+            COLORS[color],
+            truncate > 0 && `line-clamp-${truncate}`,
+            uppercase && "uppercase",
+            align === "center" && "text-center",
+            align === "right" && "text-right",
+            classes,
+        ),
+    );
+
+    const tag = $derived(`h${level}` as const);
+</script>
+
+<svelte:element this={tag} class={classFinal}>
+    {@render children()}
+</svelte:element>

--- a/src/components/profile/BaseActivityCard.svelte
+++ b/src/components/profile/BaseActivityCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { t } from "../../i18n/store";
+    import Title from "../library/typography/Title.svelte";
 
     import type { Snippet } from "svelte";
 
@@ -126,9 +127,9 @@
 
         <!-- Content - centered and takes up available space -->
         <div class="relative z-10 flex grow flex-col items-center justify-center gap-1 text-center">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t(titleKey)}
-            </h2>
+            </Title>
             {#if emptyMessageKey}
                 <p class="text-content text-base">
                     {$t(emptyMessageKey)}
@@ -195,9 +196,9 @@
 
         <!-- Recent items list -->
         <div class="relative z-10 mb-4 flex min-h-30 flex-grow flex-col gap-3">
-            <h3 class="text-base font-bold text-black">
+            <Title level={3} variant="field">
                 {$t(recentTitleKey)}
-            </h3>
+            </Title>
             <ul class="flex flex-col gap-2">
                 {@render children?.()}
             </ul>

--- a/src/components/profile/CTACard.svelte
+++ b/src/components/profile/CTACard.svelte
@@ -22,6 +22,8 @@
      * ```
      */
 
+    import Title from "../library/typography/Title.svelte";
+
     interface Button {
         label: string;
         href: string;
@@ -63,12 +65,14 @@
 >
     <!-- Content -->
     <div class="flex flex-col gap-4">
-        <h2
-            class="text-3xl leading-tight font-bold md:text-4xl"
+        <Title
+            level={2}
+            variant="section"
+            class="leading-tight"
             style="display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; overflow: hidden;"
         >
             {title}
-        </h2>
+        </Title>
         <p class="text-sm leading-tight md:text-base md:leading-normal">
             {description}
         </p>

--- a/src/components/profile/DonatedProjectsSection.svelte
+++ b/src/components/profile/DonatedProjectsSection.svelte
@@ -14,6 +14,7 @@
     import { addMoney } from "../../utils/money";
     import CampaignCard from "../home/CampaignCard.svelte";
     import Carousel from "../library/layout/Carousel.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { Money, GatewayCharge, User } from "../../openapi/client/types.gen.ts";
     import type { Campaign } from "../../types/campaign";
@@ -173,9 +174,9 @@
 
 {#if !loading && donatedCampaigns.length > 0}
     <div class="flex flex-col gap-6">
-        <h2 class="text-3xl font-bold text-black md:text-4xl">
+        <Title level={2} variant="section">
             {$t("pages.me.donatedProjects.title")}
-        </h2>
+        </Title>
         <Carousel itemsPerGroup={3} gap={24} showDots={false}>
             {#each donatedCampaigns as campaign, index (campaign.id)}
                 <CampaignCard

--- a/src/components/profile/MatchfundingCallCard.svelte
+++ b/src/components/profile/MatchfundingCallCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { t } from "../../i18n/store";
     import { formatAmountWithSymbol } from "../../utils/currencies";
+    import Title from "../library/typography/Title.svelte";
 
     import type { MatchfundingCall } from "../../types/me-page";
 
@@ -58,11 +59,14 @@
             <div class="flex w-full flex-col gap-4">
                 <!-- Title -->
                 <div class="flex w-full flex-col gap-2">
-                    <h3
-                        class="min-w-full text-3xl leading-tight font-bold text-white md:text-4xl lg:text-5xl"
+                    <Title
+                        level={3}
+                        variant="section"
+                        color="white"
+                        class="min-w-full leading-tight"
                     >
                         {call.title}
-                    </h3>
+                    </Title>
                 </div>
 
                 <!-- Stats Row (Horizontal on desktop, vertical on mobile) -->

--- a/src/components/profile/MatchfundingSection.svelte
+++ b/src/components/profile/MatchfundingSection.svelte
@@ -13,6 +13,7 @@
     import { extractId } from "../../utils/extractId";
     import { toCollectionItems } from "../../utils/hydra.ts";
     import Carousel from "../library/layout/Carousel.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { MatchCall, MatchCallSubmission, User } from "../../openapi/client/types.gen.ts";
     import type { MatchfundingCall } from "../../types/me-page";
@@ -163,18 +164,18 @@
 {#if loading}
     <!-- Loading State -->
     <div class="flex flex-col gap-6">
-        <h2 class="text-2xl font-bold text-black md:text-3xl">
+        <Title level={2} variant="subsection">
             {$t("pages.me.matchfunding.section.title")}
-        </h2>
+        </Title>
         <!-- Single hero card skeleton matching actual dimensions -->
         <div class="bg-grey h-64 w-full animate-pulse rounded-4xl md:h-80 lg:h-96"></div>
     </div>
 {:else if error}
     <!-- Error State -->
     <div class="flex flex-col gap-6">
-        <h2 class="text-2xl font-bold text-black md:text-3xl">
+        <Title level={2} variant="subsection">
             {$t("pages.me.matchfunding.section.title")}
-        </h2>
+        </Title>
         <p class="text-content text-base leading-normal">
             {$t("pages.me.matchfunding.section.error")}
         </p>
@@ -182,9 +183,9 @@
 {:else if matchfundingCalls.length > 0}
     <!-- Filled State -->
     <div class="flex flex-col gap-6">
-        <h2 class="text-2xl font-bold text-black md:text-3xl">
+        <Title level={2} variant="subsection">
             {$t("pages.me.matchfunding.section.title")}
-        </h2>
+        </Title>
         <Carousel itemsPerGroup={1} gap={24} showDots={false}>
             {#each matchfundingCalls as call (call.id)}
                 <MatchfundingCallCard {lang} {call} />

--- a/src/components/profile/OwnedProjectsSection.svelte
+++ b/src/components/profile/OwnedProjectsSection.svelte
@@ -8,6 +8,7 @@
     import { toCollectionItems } from "../../utils/hydra.ts";
     import CampaignCard from "../home/CampaignCard.svelte";
     import Carousel from "../library/layout/Carousel.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { Money, Project, User } from "../../openapi/client/types.gen.ts";
     import type { Campaign } from "../../types/campaign";
@@ -124,9 +125,9 @@
 
 {#if !loading && ownedProjects.length > 0}
     <div class="flex flex-col gap-6">
-        <h2 class="text-3xl font-bold text-black md:text-4xl">
+        <Title level={2} variant="section">
             {$t("pages.me.ownedProjects.title")}
-        </h2>
+        </Title>
         <Carousel itemsPerGroup={3} gap={24} showDots={false}>
             {#each ownedProjects as campaign, index (campaign.id)}
                 <CampaignCard

--- a/src/components/profile/ProfileInfo.svelte
+++ b/src/components/profile/ProfileInfo.svelte
@@ -6,6 +6,7 @@
     import MediumIcon from "../icons/social/MediumIcon.svelte";
     import XIcon from "../icons/social/XIcon.svelte";
     import TerritoryTag from "../project/TerritoryTag.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { Link, Territory } from "../../openapi/client/types.gen";
 
@@ -67,9 +68,9 @@
 
 <div class="mt-28 flex w-full flex-col items-center gap-4">
     <!-- Name -->
-    <h1 class="text-secondary text-2xl leading-tight font-bold">
+    <Title level={1} variant="subsection" color="secondary" class="leading-tight">
         {displayName}
-    </h1>
+    </Title>
 
     <!-- Location -->
     {#if territory}

--- a/src/components/project/PlatformUpdateCard.svelte
+++ b/src/components/project/PlatformUpdateCard.svelte
@@ -5,6 +5,7 @@
     import { locale } from "../../i18n/store";
     import { type ProjectUpdate } from "../../openapi/client/index";
     import { formatDate } from "../../utils/dates.ts";
+    import Title from "../library/typography/Title.svelte";
 
     import type { ProjectUpdateCardType } from "./ProjectUpdateCard.svelte";
 
@@ -72,9 +73,14 @@
                 />
             </svg>
 
-            <h2 class={twMerge("relative z-10 font-bold text-white", titleStyles[type])}>
+            <Title
+                level={2}
+                variant="subsection"
+                color="white"
+                class={`relative z-10 ${titleStyles[type]}`}
+            >
                 {update.title}
-            </h2>
+            </Title>
         </div>
     </div>
 </div>

--- a/src/components/project/ProjectCommunity.svelte
+++ b/src/components/project/ProjectCommunity.svelte
@@ -10,6 +10,7 @@
     import ActionableButton from "../library/buttons/ActionableButton.svelte";
     import Loader from "../library/feedback/Loader.svelte";
     import Grid from "../library/layout/Grid.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { Accounting, Project, ProjectSupport } from "../../openapi/client/index";
 
@@ -92,9 +93,15 @@
             <Loader />
         </div>
     {:else}
-        <h2 class="text-secondary line-clamp-2 flex max-w-2xl text-4xl font-bold">
+        <Title
+            level={2}
+            variant="headline"
+            color="secondary"
+            truncate={2}
+            class="flex max-w-2xl"
+        >
             {$t("pages.project.view.tabs.community.content.title")}
-        </h2>
+        </Title>
         <div class="flex flex-col gap-6">
             {#if hasMatchfunding}
                 <Grid

--- a/src/components/project/ProjectRewards.svelte
+++ b/src/components/project/ProjectRewards.svelte
@@ -10,6 +10,7 @@
     import { extractId } from "../../utils/extractId";
     import Button from "../library/buttons/Button.svelte";
     import Grid from "../library/layout/Grid.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { ProjectReward, Project } from "../../openapi/client/index";
 
@@ -82,9 +83,9 @@
 
 <section>
     <div class="flex flex-col gap-12">
-        <h2 class="text-secondary text-4xl font-bold">
+        <Title level={2} variant="headline" color="secondary">
             {$t("pages.project.view.rewards.title")}
-        </h2>
+        </Title>
         <Grid>
             <div
                 class:opacity-50={!isAvailable}
@@ -92,9 +93,15 @@
                 class="border-grey flex basis-1/3 flex-col justify-between gap-6 rounded-4xl border bg-[#FFF] p-6 shadow-[0px_1px_3px_0px_#0000001A]"
             >
                 <div class="flex flex-col gap-6">
-                    <h3 class="text-secondary w-full text-left text-2xl font-semibold">
+                    <Title
+                        level={3}
+                        variant="subsection"
+                        color="secondary"
+                        weight="bold"
+                        class="w-full text-left"
+                    >
                         {$t("pages.project.view.rewards.donationFree.title")}
-                    </h3>
+                    </Title>
                     <p class="text-sm whitespace-pre-line text-gray-800">
                         {$t("pages.project.view.rewards.donationFree.description")}
                     </p>

--- a/src/components/project/ProjectUpdate.svelte
+++ b/src/components/project/ProjectUpdate.svelte
@@ -11,6 +11,7 @@
     import AlertIcon from "../icons/status/AlertIcon.svelte";
     import Button from "../library/buttons/Button.svelte";
     import Carousel from "../library/layout/Carousel.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { Project, ProjectUpdate } from "../../openapi/client/index";
 
@@ -104,9 +105,15 @@
 </script>
 
 <div class="flex flex-col gap-10">
-    <h2 class="text-secondary line-clamp-2 flex max-w-2xl text-4xl font-bold">
+    <Title
+        level={2}
+        variant="headline"
+        color="secondary"
+        truncate={2}
+        class="flex max-w-2xl"
+    >
         {$t("pages.project.view.tabs.updates.content.title")}
-    </h2>
+    </Title>
     <Carousel
         bind:activeCard
         gap={24}
@@ -156,9 +163,9 @@
                     {$t("pages.project.view.tabs.updates.modalTitle")}
                 </div>
             {/if}
-            <h3 class="text-secondary text-3xl font-bold">
+            <Title level={3} variant="section" color="secondary">
                 {selected?.title}
-            </h3>
+            </Title>
             <div class="marked-content text-content flex flex-col gap-4">
                 {#await renderMarkdown(selected.body) then content}
                     {@html content}

--- a/src/components/project/ProjectUpdateCard.svelte
+++ b/src/components/project/ProjectUpdateCard.svelte
@@ -9,6 +9,7 @@
     import { extractId } from "../../utils/extractId.ts";
     import { renderMarkdown } from "../../utils/renderMarkdown";
     import Button from "../library/buttons/Button.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { User } from "../../openapi/client/types.gen.ts";
     import type { MouseEventHandler } from "svelte/elements";
@@ -135,9 +136,9 @@
     </div>
     <div class="flex min-h-0 flex-1 flex-col justify-between gap-6">
         <div class={twMerge("flex flex-col", contentGroupStyles[type])}>
-            <h2 class={twMerge("text-secondary font-bold", titleStyles[type])}>
+            <Title level={2} variant="subsection" color="secondary" class={titleStyles[type]}>
                 {update.title}
-            </h2>
+            </Title>
             {#if update.subtitle || update.body}
                 <div class="flex flex-col gap-2 leading-5">
                     <p class="line-clamp-2 text-base font-bold text-black">{update.subtitle}</p>

--- a/src/components/project/PublicBudgetCard.svelte
+++ b/src/components/project/PublicBudgetCard.svelte
@@ -2,6 +2,7 @@
     import { t } from "../../i18n/store";
     import { budgetTypeClasses } from "../../utils/budgetColors";
     import { formatCurrency } from "../../utils/currencies";
+    import Title from "../library/typography/Title.svelte";
 
     import type { ProjectBudgetItem } from "../../openapi/client";
 
@@ -32,7 +33,9 @@
     }}
 >
     <div class="flex flex-col gap-4">
-        <h2 class="text-secondary line-clamp-1 text-2xl">{item.title}</h2>
+        <Title level={2} variant="subsection" color="secondary" truncate={1}>
+            {item.title}
+        </Title>
         <p class="text-content line-clamp-3 font-normal">
             {item.description}
         </p>

--- a/src/components/project/Reward.svelte
+++ b/src/components/project/Reward.svelte
@@ -6,6 +6,7 @@
     import UnitIcon from "../icons/UnitIcon.svelte";
     import UserIcon from "../icons/user/User.svelte";
     import Button from "../library/buttons/Button.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { Project, ProjectReward } from "../../openapi/client";
 
@@ -28,7 +29,14 @@
     class:cursor-not-allowed={!isAvailable}
 >
     <div class="flex flex-col gap-4">
-        <h3 class="text-secondary line-clamp-2 w-full text-left text-2xl font-semibold">
+        <Title
+            level={3}
+            variant="subsection"
+            color="secondary"
+            weight="bold"
+            truncate={2}
+            class="w-full text-left"
+        >
             <div>
                 {@html $t(
                     "domain.project.reward.byAtLeast",
@@ -39,7 +47,7 @@
                 )}
             </div>
             {reward.title}
-        </h3>
+        </Title>
 
         {#if reward.description}
             <div class="marked-content line-clamp-7 text-sm whitespace-pre-line text-gray-800">

--- a/src/components/project/RisksCard.svelte
+++ b/src/components/project/RisksCard.svelte
@@ -2,6 +2,7 @@
     import { t } from "../../i18n/store";
     import Button from "../library/buttons/Button.svelte";
     import Tag from "../library/tags/Tag.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { ProjectReviewArea } from "../../openapi/client";
 
@@ -49,15 +50,15 @@
             <div class="flex flex-col gap-1">
                 <!-- TODO: Messages reactivity functionality (new messages styling and handling + future chatbox logic) -->
                 {#if newMessage}
-                    <h2 class="text-secondary text-2xl font-bold">
+                    <Title level={2} variant="subsection" color="secondary">
                         {review.title}
-                    </h2>
+                    </Title>
                     <span class="text-content text-sm/4">32 chats. Última actividad 12/11/2025</span
                     >
                 {:else}
-                    <h2 class="text-secondary text-2xl font-bold">
+                    <Title level={2} variant="subsection" color="secondary">
                         {review.title}
-                    </h2>
+                    </Title>
                     <span class="text-content text-sm/4">32 chats. Última actividad 12/11/2025</span
                     >
                 {/if}

--- a/src/components/project/SingleProject.svelte
+++ b/src/components/project/SingleProject.svelte
@@ -18,6 +18,7 @@
     import { getLanguageDisplayName } from "../../utils/lang";
     import LanguagesDropdown from "../header/LanguagesDropdown.svelte";
     import RememberIcon from "../icons/actions/RememberIcon.svelte";
+    import Title from "../library/typography/Title.svelte";
     import Arrow from "../icons/navigation/Arrow.svelte";
     import Button from "../library/buttons/Button.svelte";
     import Toast from "../library/feedback/Toast.svelte";
@@ -147,17 +148,17 @@
     <div class="my-10 flex w-full flex-col-reverse gap-5 lg:flex-row lg:justify-between">
         <div class="flex w-full flex-col gap-2.5 lg:w-[70%]">
             <div class="flex flex-col gap-2">
-                <h3 class="text-content text-xl font-bold lg:text-2xl">
+                <p class="text-content text-xl font-bold lg:text-2xl">
                     <Thtml
                         key="pages.project.view.owner"
                         vars={{
                             owner: `<span class="font-bold text-black underline">${owner.displayName}</span>`,
                         }}
                     />
-                </h3>
-                <h1 class="text-content text-3xl font-bold lg:text-4xl">
+                </p>
+                <Title level={1} variant="section" class="text-content">
                     {project.title}
-                </h1>
+                </Title>
             </div>
 
             <div>
@@ -217,9 +218,9 @@
     </div>
     <div class="flex flex-col gap-8">
         <div class="flex items-center justify-between">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.view.rewards.trending")}
-            </h2>
+            </Title>
             <Button kind="secondary" class="hidden lg:flex" onclick={scrollToRewards}>
                 <Arrow />{$t("pages.project.view.rewards.showAll")}
             </Button>

--- a/src/components/project/TopReward.svelte
+++ b/src/components/project/TopReward.svelte
@@ -4,6 +4,7 @@
     import { formatCurrency } from "../../utils/currencies";
     import { renderMarkdown } from "../../utils/renderMarkdown";
     import Button from "../library/buttons/Button.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     import type { Project, ProjectReward } from "../../openapi/client";
 
@@ -37,9 +38,16 @@
     class:cursor-not-allowed={!isAvailable}
 >
     <div class="flex flex-col gap-4">
-        <h3 class="text-secondary line-clamp-2 w-full text-left text-2xl font-semibold">
+        <Title
+            level={3}
+            variant="subsection"
+            color="secondary"
+            weight="bold"
+            truncate={2}
+            class="w-full text-left"
+        >
             {reward.title}
-        </h3>
+        </Title>
 
         {#if reward.description}
             <div class="marked-content line-clamp-7 text-sm whitespace-pre-line text-gray-800">

--- a/src/components/project/edit/AdminBudgetCard.svelte
+++ b/src/components/project/edit/AdminBudgetCard.svelte
@@ -13,6 +13,7 @@
     import { budgetTypeClasses } from "../../../utils/budgetColors";
     import { formatCurrency } from "../../../utils/currencies";
     import Close from "../../icons/navigation/Close.svelte";
+    import Title from "../../library/typography/Title.svelte";
     import Button from "../../library/buttons/Button.svelte";
 
     import type { Project, ProjectBudgetItem } from "../../../openapi/client";
@@ -134,7 +135,9 @@
                         : $t("domain.project.budget.optimum")}
                 </span>
             </div>
-            <h2 class="text-secondary line-clamp-1 text-2xl">{item.title}</h2>
+            <Title level={2} variant="subsection" color="secondary" truncate={1}>
+                {item.title}
+            </Title>
             <p class="text-content line-clamp-3 font-normal">
                 {item.description}
             </p>

--- a/src/components/project/edit/BudgetModal.svelte
+++ b/src/components/project/edit/BudgetModal.svelte
@@ -12,6 +12,7 @@
     import Select from "../../library/inputs/Select.svelte";
     import TextArea from "../../library/inputs/TextArea.svelte";
     import TextInput from "../../library/inputs/TextInput.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     import type { ProjectBudgetItem } from "../../../openapi/client";
 
@@ -125,9 +126,9 @@
                 {$t("system.validation.missingRequiredFields")}
             </Toast>
         {/if}
-        <h2 class="text-xl font-bold text-black">
+        <Title level={2} variant="subsection">
             {$t("pages.project.edit.budget.modal.title")}
-        </h2>
+        </Title>
         <p class="text-content line-clamp-1 overflow-hidden text-base font-normal text-ellipsis">
             {$t("pages.project.edit.budget.modal.description")}
         </p>

--- a/src/components/project/edit/BudgetStep.svelte
+++ b/src/components/project/edit/BudgetStep.svelte
@@ -13,6 +13,7 @@
     import Toast from "../../library/feedback/Toast.svelte";
     import Grid from "../../library/layout/Grid.svelte";
     import LoadingSpinner from "../../search/LoadingSpinner.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     let {
         project,
@@ -84,9 +85,9 @@
         {/each}
     {/if}
     <div class="space-y-4">
-        <h1 class="text-3xl leading-12 font-bold text-black lg:text-[2.5rem]">
+        <Title level={1} variant="section">
             {$t("pages.project.edit.budget.title")}
-        </h1>
+        </Title>
         <p class="text-content text-base">{$t("pages.project.edit.budget.subtitle")}</p>
     </div>
 

--- a/src/components/project/edit/CampaignInfoStep.svelte
+++ b/src/components/project/edit/CampaignInfoStep.svelte
@@ -14,6 +14,8 @@
     - All rich text fields have minimum character requirements
 -->
 <script lang="ts">
+    import Title from "../../library/typography/Title.svelte";
+
     import MediaUploader from "./MediaUploader.svelte";
     import RichTextEditor from "./RichTextEditor.svelte";
     import VideoUrlInput from "./VideoUrlInput.svelte";
@@ -127,9 +129,9 @@
 <div class="w-auto max-w-167 space-y-10">
     <!-- Page Header -->
     <div class="space-y-4">
-        <h1 class="text-3xl leading-12 font-bold text-black lg:text-[2.5rem]">
+        <Title level={1} variant="section">
             {$t("pages.project.edit.campaignInfo.title")}
-        </h1>
+        </Title>
         <p class="text-content text-base">{$t("pages.project.edit.campaignInfo.subtitle")}</p>
     </div>
 
@@ -137,10 +139,10 @@
         <!-- Media Section -->
         <section data-field="media" class="space-y-4">
             <div>
-                <h2 class="mb-1 text-2xl font-bold text-black">
+                <Title level={2} variant="subsection" class="mb-1">
                     {$t("pages.project.edit.campaignInfo.media.title")}
                     <span aria-label="required">*</span>
-                </h2>
+                </Title>
                 <p class="text-content text-base">
                     {$t("pages.project.edit.campaignInfo.media.description")}
                 </p>

--- a/src/components/project/edit/CollaborationsStep.svelte
+++ b/src/components/project/edit/CollaborationsStep.svelte
@@ -5,6 +5,7 @@
     import Button from "../../library/buttons/Button.svelte";
     import Grid from "../../library/layout/Grid.svelte";
     import LoadingSpinner from "../../search/LoadingSpinner.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     import type { Project, ProjectCollaboration } from "../../../openapi/client";
 
@@ -36,9 +37,9 @@
 
 <div class="w-full space-y-10">
     <div class="flex w-full flex-col gap-4">
-        <h2 class="text-[2.5rem] leading-12 font-bold text-black">
+        <Title level={2} variant="headline">
             {$t("pages.project.edit.collaborations.title")}
-        </h2>
+        </Title>
         <p class="text-content text-base font-normal">
             {$t("pages.project.edit.collaborations.subtitle")}
         </p>

--- a/src/components/project/edit/CollabsCard.svelte
+++ b/src/components/project/edit/CollabsCard.svelte
@@ -12,6 +12,7 @@
     import { renderMarkdown } from "../../../utils/renderMarkdown";
     import Close from "../../icons/navigation/Close.svelte";
     import Button from "../../library/buttons/Button.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     import type { Project, ProjectCollaboration } from "../../../openapi/client";
 
@@ -91,9 +92,15 @@
             <Close class="size-5" />
         </button>
         <div class="flex flex-col">
-            <h3 class="text-secondary line-clamp-2 w-full text-left text-2xl font-bold">
+            <Title
+                level={3}
+                variant="subsection"
+                color="secondary"
+                truncate={2}
+                class="w-full text-left"
+            >
                 {collab.title}
-            </h3>
+            </Title>
 
             {#if collab.description}
                 <div class="marked-content line-clamp-7 text-sm whitespace-pre-line text-gray-800">

--- a/src/components/project/edit/CollabsModal.svelte
+++ b/src/components/project/edit/CollabsModal.svelte
@@ -7,6 +7,7 @@
     import { validationErrors } from "../../../stores/drafts/projectDraft";
     import Button from "../../library/buttons/Button.svelte";
     import Toast from "../../library/feedback/Toast.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     import type { Project, ProjectCollaboration } from "../../../openapi/client";
     import type { ClassNameValue } from "tailwind-merge";
@@ -71,9 +72,9 @@
                 {$t("system.validation.missingRequiredFields")}
             </Toast>
         {/if}
-        <h2 class="text-xl font-bold text-black">
+        <Title level={2} variant="subsection">
             {$t("pages.project.edit.collaborations.modal.title")}
-        </h2>
+        </Title>
         <p class="text-content line-clamp-1 overflow-hidden text-base font-normal text-ellipsis">
             {$t("pages.project.edit.collaborations.modal.description")}
         </p>

--- a/src/components/project/edit/ConfigurationStep.svelte
+++ b/src/components/project/edit/ConfigurationStep.svelte
@@ -12,6 +12,7 @@
 -->
 <script lang="ts">
     import { onMount } from "svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     import RoundSelector from "./RoundSelector.svelte";
     import CategorySelect from "../../../components/library/inputs/CategorySelect.svelte";
@@ -109,9 +110,9 @@
 <div class="space-y-8">
     <!-- Page Header -->
     <div class="space-y-4">
-        <h1 class="text-[2.5rem]/12 font-bold text-black">
+        <Title level={1} variant="headline">
             {$t("pages.project.edit.configuration.title")}
-        </h1>
+        </Title>
         <p class="text-content text-base font-normal">
             {$t("pages.project.edit.configuration.subtitle")}
         </p>
@@ -120,9 +121,9 @@
     <!-- Categories Section -->
     <div class="space-y-4">
         <div class="space-y-4">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.create.categories.title")}
-            </h2>
+            </Title>
             <p class="text-black transition-all duration-300 ease-in-out">
                 {$t("pages.project.create.categories.subtitle")}
             </p>
@@ -138,9 +139,9 @@
     <!-- Release Date Section -->
     <div class="space-y-4">
         <div class="space-y-4">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.create.release.title")}
-            </h2>
+            </Title>
             <p class="text-content text-base font-normal">
                 {$t("pages.project.create.release.subtitle")}
             </p>
@@ -157,9 +158,9 @@
     <!-- Funding Rounds Section -->
     <div class="space-y-6">
         <div class="space-y-4">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.edit.configuration.rounds.title")}
-            </h2>
+            </Title>
             <p class="text-content text-base font-normal">
                 {$t("pages.project.edit.configuration.rounds.description")}
             </p>

--- a/src/components/project/edit/CreateCard.svelte
+++ b/src/components/project/edit/CreateCard.svelte
@@ -8,6 +8,7 @@
     import MoreAndLess from "../../icons/filters/MoreAndLess.svelte";
     import Button from "../../library/buttons/Button.svelte";
     import Toast from "../../library/feedback/Toast.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     import type { Project } from "../../../openapi/client";
 
@@ -57,13 +58,14 @@
     )}
 >
     <div class="flex flex-col gap-4 text-ellipsis">
-        <h2
-            class="text-purple-soft font-bold {variant === 'budget'
-                ? 'text-2xl leading-8'
-                : 'text-4xl leading-12'}"
+        <Title
+            level={2}
+            variant={variant === "budget" ? "subsection" : "headline"}
+            color="purple-soft"
+            class={variant === "budget" ? "leading-8" : "leading-12"}
         >
             {title}
-        </h2>
+        </Title>
         <p class="text-variant1 mb-4 text-base font-normal">
             {description}
         </p>

--- a/src/components/project/edit/DeleteModal.svelte
+++ b/src/components/project/edit/DeleteModal.svelte
@@ -3,6 +3,7 @@
 
     import { t } from "../../../i18n/store";
     import Button from "../../library/buttons/Button.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     let {
         open = $bindable(false),
@@ -24,9 +25,9 @@
     footerClass="md:p-0 p-0 flex items-center justify-end gap-4"
 >
     {#snippet header()}
-        <h2 class="text-xl font-bold text-black">
+        <Title level={2} variant="subsection">
             {$t(`pages.project.edit.${variant}.deleteModal.title`)}
-        </h2>
+        </Title>
     {/snippet}
     <p class="text-content text-base font-normal">
         {$t(`pages.project.edit.${variant}.deleteModal.description`)}

--- a/src/components/project/edit/OwnerInfoStep.svelte
+++ b/src/components/project/edit/OwnerInfoStep.svelte
@@ -9,6 +9,7 @@
     import RadioButton from "../../library/inputs/RadioButton.svelte";
     import TextInput from "../../library/inputs/TextInput.svelte";
     import ToggleSwitch from "../../library/inputs/ToggleSwitch.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     import type { Project } from "../../../openapi/client";
     import type { UploadedFile } from "../../../stores/drafts/projectDraft";
@@ -100,9 +101,9 @@
     <div class="flex flex-col gap-10">
         <!-- Header -->
         <div class="space-y-4">
-            <h1 class="text-[2.5rem] leading-12 font-bold text-black lg:text-[2.5rem]">
+            <Title level={1} variant="headline">
                 {$t("pages.project.edit.aboutYou.title")}
-            </h1>
+            </Title>
             <p class="text-content text-base">{$t("pages.project.edit.aboutYou.subtitle")}</p>
         </div>
 
@@ -116,9 +117,9 @@
 
         <!-- Legal Entity -->
         <div class="flex flex-col gap-3">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.edit.aboutYou.legalEntity")}
-            </h2>
+            </Title>
             <p class="text-content text-base">
                 {$t("pages.project.edit.aboutYou.legalEntityHelper")}
             </p>
@@ -136,9 +137,9 @@
 
         <!-- Name -->
         <div class="flex flex-col gap-2">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.edit.aboutYou.name")}
-            </h2>
+            </Title>
             <p class="text-content text-base">{$t("pages.project.edit.aboutYou.nameHelper")}</p>
             <div onfocusout={() => touch("name")}>
                 <TextInput
@@ -152,9 +153,9 @@
 
         <!-- NIF -->
         <div class="flex flex-col gap-2">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.edit.aboutYou.taxId")}
-            </h2>
+            </Title>
             <p class="text-content text-base">{$t("pages.project.edit.aboutYou.taxIdHelper")}</p>
             <div onfocusout={() => touch("taxId")}>
                 <TextInput
@@ -168,9 +169,9 @@
 
         <!-- Location/Territory -->
         <div class="flex flex-col gap-2">
-            <h2 class="text-2xl font-bold text-black">
+            <Title level={2} variant="subsection">
                 {$t("pages.project.edit.aboutYou.location")}
-            </h2>
+            </Title>
             <p class="text-content text-base">{$t("pages.project.edit.aboutYou.locationHelper")}</p>
             <AddressAutocomplete
                 name="address"
@@ -202,9 +203,9 @@
         <!-- Private contacts data -->
         <div class="flex flex-col gap-4">
             <div class="flex flex-col gap-1">
-                <h2 class="text-2xl font-bold text-black">
-                    {$t("pages.project.edit.aboutYou.privateContacts")}
-                </h2>
+            <Title level={2} variant="subsection">
+                {$t("pages.project.edit.aboutYou.privateContacts")}
+            </Title>
                 <p class="text-content text-base">
                     {$t("pages.project.edit.aboutYou.privateContactsHelper")}
                 </p>
@@ -339,9 +340,9 @@
         <!-- Payment Data -->
         <div class="flex flex-col gap-4">
             <div class="flex flex-col gap-1">
-                <h2 class="text-2xl font-bold text-black">
+                <Title level={2} variant="subsection">
                     {$t("pages.project.edit.aboutYou.paymentData.title")}
-                </h2>
+                </Title>
                 <p class="text-content text-base">
                     {$t("pages.project.edit.aboutYou.paymentData.subtitle")}
                 </p>

--- a/src/components/project/edit/ProjectEditorShell.svelte
+++ b/src/components/project/edit/ProjectEditorShell.svelte
@@ -32,6 +32,7 @@
     import Button from "../../library/buttons/Button.svelte";
     import Toast from "../../library/feedback/Toast.svelte";
     import TabNavigation, { type Tab } from "../../library/layout/TabNavigation.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     import type { Project } from "../../../openapi/client";
     import type { Snippet } from "svelte";
@@ -138,9 +139,9 @@
                         />
                     </svg>
                     <div class="flex-1">
-                        <h3 class="text-secondary text-sm font-semibold">
+                        <Title level={3} variant="subsection" color="secondary" class="text-sm">
                             {$t("pages.project.edit.errors.storage.title")}
-                        </h3>
+                        </Title>
                         <p class="text-tertiary mt-1 text-sm">
                             {#if $persistenceError === "storage_quota_exceeded"}
                                 {$t("pages.project.edit.errors.storage.quota_exceeded")}

--- a/src/components/project/edit/ProjectEditorShell.svelte
+++ b/src/components/project/edit/ProjectEditorShell.svelte
@@ -32,7 +32,6 @@
     import Button from "../../library/buttons/Button.svelte";
     import Toast from "../../library/feedback/Toast.svelte";
     import TabNavigation, { type Tab } from "../../library/layout/TabNavigation.svelte";
-    import Title from "../../library/typography/Title.svelte";
 
     import type { Project } from "../../../openapi/client";
     import type { Snippet } from "svelte";
@@ -139,9 +138,9 @@
                         />
                     </svg>
                     <div class="flex-1">
-                        <Title level={3} variant="subsection" color="secondary" class="text-sm">
+                        <span class="text-secondary text-sm font-semibold">
                             {$t("pages.project.edit.errors.storage.title")}
-                        </Title>
+                        </span>
                         <p class="text-tertiary mt-1 text-sm">
                             {#if $persistenceError === "storage_quota_exceeded"}
                                 {$t("pages.project.edit.errors.storage.quota_exceeded")}

--- a/src/components/project/edit/RewardItemsSelector.svelte
+++ b/src/components/project/edit/RewardItemsSelector.svelte
@@ -2,6 +2,7 @@
     import { t } from "../../../i18n/store";
     import MoreAndLess from "../../icons/filters/MoreAndLess.svelte";
     import InfinityIcon from "../../icons/Infinity.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     let {
         value = $bindable(1),
@@ -23,9 +24,9 @@
 </script>
 
 <div class="flex flex-col gap-4">
-    <h3 class="text-secondary text-base font-bold">
+    <Title level={3} variant="field" color="secondary">
         {$t("pages.project.edit.rewards.modal.unitsExisting")}
-    </h3>
+    </Title>
 
     <div class="flex items-center gap-10">
         <div class="flex gap-4">

--- a/src/components/project/edit/RewardsCard.svelte
+++ b/src/components/project/edit/RewardsCard.svelte
@@ -18,6 +18,7 @@
     import Close from "../../icons/navigation/Close.svelte";
     import UnitIcon from "../../icons/UnitIcon.svelte";
     import Button from "../../library/buttons/Button.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     import type { Project, ProjectReward } from "../../../openapi/client";
 
@@ -116,14 +117,20 @@
         {/if}
 
         <div class="flex flex-col">
-            <h3 class="text-secondary line-clamp-2 w-full text-left text-2xl font-bold">
+            <Title
+                level={3}
+                variant="subsection"
+                color="secondary"
+                truncate={2}
+                class="w-full text-left"
+            >
                 <div>
                     {@html $t("domain.project.reward.byAtLeast", {
                         amount: formatCurrency(reward.money.amount, reward.money.currency),
                     })}
                 </div>
                 {reward.title}
-            </h3>
+            </Title>
 
             {#if reward.description}
                 <div class="marked-content line-clamp-7 text-sm whitespace-pre-line text-gray-800">

--- a/src/components/project/edit/RewardsModal.svelte
+++ b/src/components/project/edit/RewardsModal.svelte
@@ -15,6 +15,7 @@
     import FileUpload from "../../library/inputs/FileUpload.svelte";
     import TextArea from "../../library/inputs/TextArea.svelte";
     import TextInput from "../../library/inputs/TextInput.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     import type { Project, ProjectReward } from "../../../openapi/client";
     import type { UploadedFile } from "../../../stores/drafts/projectDraft";
@@ -124,9 +125,9 @@
                 {$t("system.validation.missingRequiredFields")}
             </Toast>
         {/if}
-        <h2 class="text-xl font-bold text-black">
+        <Title level={2} variant="subsection">
             {$t("pages.project.edit.rewards.modal.title")}
-        </h2>
+        </Title>
         <p class="text-content line-clamp-1 overflow-hidden text-base font-normal text-ellipsis">
             {$t("pages.project.edit.rewards.modal.description")}
         </p>

--- a/src/components/project/edit/RewardsStep.svelte
+++ b/src/components/project/edit/RewardsStep.svelte
@@ -5,6 +5,7 @@
     import Button from "../../library/buttons/Button.svelte";
     import Grid from "../../library/layout/Grid.svelte";
     import LoadingSpinner from "../../search/LoadingSpinner.svelte";
+    import Title from "../../library/typography/Title.svelte";
 
     import type { Project, ProjectReward } from "../../../openapi/client";
 
@@ -34,9 +35,9 @@
 
 <div class="w-full space-y-10">
     <div class="flex w-full flex-col gap-4">
-        <h2 class="text-[2.5rem] leading-12 font-bold text-black">
+        <Title level={2} variant="headline">
             {$t("pages.project.edit.rewards.title")}
-        </h2>
+        </Title>
         <p class="text-content text-base font-normal">
             {$t("pages.project.edit.rewards.subtitle")}
         </p>

--- a/src/components/search/CategoryFilter.svelte
+++ b/src/components/search/CategoryFilter.svelte
@@ -12,6 +12,7 @@ Implements active/inactive pill states matching Figma design
     } from "../../openapi/client";
     import { extractId } from "../../utils/extractId";
     import CategorySelect from "../library/inputs/CategorySelect.svelte";
+    import Title from "../library/typography/Title.svelte";
 
     interface Props {
         selectedCategories?: string[];
@@ -53,9 +54,9 @@ Implements active/inactive pill states matching Figma design
 
 <div class="w-full">
     {#if showLabel}
-        <h3 class="font-body mb-6 text-base font-bold text-black">
+        <Title level={3} variant="field" class="font-body mb-6">
             {$t("pages.search.filters.categoryLabel")}
-        </h3>
+        </Title>
     {/if}
 
     {#await categories then categories}

--- a/src/components/search/SearchErrorAlert.svelte
+++ b/src/components/search/SearchErrorAlert.svelte
@@ -43,9 +43,9 @@ Displays basic error messages with retry functionality
 
             <!-- Error Content -->
             <div class="min-w-0 flex-1">
-                <h3 class="text-sm font-medium text-red-800">
+                <span class="text-sm font-medium text-red-800">
                     {$t("pages.search.error.title")}
-                </h3>
+                </span>
                 <p class="mt-1 text-sm text-red-700">
                     {error}
                 </p>

--- a/src/components/search/SearchFilters.svelte
+++ b/src/components/search/SearchFilters.svelte
@@ -12,6 +12,7 @@ Integrated with searchStore for state management and URL synchronization
     import SearchInput from "./SearchInput.svelte";
     import StatusFilter from "./StatusFilter.svelte";
     import TerritoryFilter from "./TerritoryFilter.svelte";
+    import Title from "../library/typography/Title.svelte";
     import { t } from "../../i18n/store";
     import { searchStore, searchFilters, type SearchFilters } from "../../stores/searchStore";
     import FilterIcon from "../icons/filters/FilterIcon.svelte";
@@ -103,18 +104,18 @@ Integrated with searchStore for state management and URL synchronization
             <!-- Status + territory filters -->
             <div class="flex flex-col items-start gap-6 lg:flex-row">
                 <div class="w-full">
-                    <h3 class="font-body mb-2 text-base font-bold text-black">
+                    <Title level={3} variant="field" class="font-body mb-2">
                         {$t("pages.search.filters.status.label")}
-                    </h3>
+                    </Title>
                     <StatusFilter
                         statuses={$searchFilters["status[]"] || []}
                         onStatusesChange={(statuses) => updateFilters({ "status[]": statuses })}
                     />
                 </div>
                 <div class="w-full">
-                    <h3 class="font-body mb-2 text-base font-bold text-black">
+                    <Title level={3} variant="field" class="font-body mb-2">
                         {$t("pages.search.filters.territoryLabel")}
-                    </h3>
+                    </Title>
                     <TerritoryFilter
                         selectedTerritory={{
                             countries: $searchFilters["territory.country[]"] || [],

--- a/src/components/search/SearchResultsClient.svelte
+++ b/src/components/search/SearchResultsClient.svelte
@@ -239,9 +239,9 @@ Manages real-time filtering of campaigns without page reloads
         <!-- Empty State -->
         <div class="flex flex-col items-center py-12 text-center" data-testid="search-empty">
             <SearchIcon class="mb-4 h-16 w-16 text-gray-400" />
-            <h3 class="mb-2 text-xl font-semibold text-gray-900">
+            <span class="mb-2 text-xl font-semibold text-gray-900">
                 {$t("pages.search.empty.title")}
-            </h3>
+            </span>
             <p class="mb-6 text-gray-600">
                 {$t("pages.search.empty.description")}
             </p>
@@ -254,9 +254,9 @@ Manages real-time filtering of campaigns without page reloads
     {#if !$hasSearchResults && !$isEmpty && !$isSearching && !isTransforming}
         <!-- Initial State - No data available -->
         <div class="py-12 text-center">
-            <h3 class="mb-2 text-xl font-semibold text-gray-900">
+            <span class="mb-2 text-xl font-semibold text-gray-900">
                 {$t("pages.search.initial.title")}
-            </h3>
+            </span>
             <p class="text-gray-600">{$t("pages.search.initial.description")}</p>
         </div>
     {/if}

--- a/src/layouts/Footer.svelte
+++ b/src/layouts/Footer.svelte
@@ -7,6 +7,7 @@
     import Linkedin from "../components/icons/social/Linkedin.svelte";
     import X from "../components/icons/social/X.svelte";
     import { t } from "../i18n/store";
+    import Title from "../components/library/typography/Title.svelte";
 </script>
 
 <footer class="text-variant1" aria-labelledby="footer-heading">
@@ -21,12 +22,14 @@
             >
                 <!-- Funding Partners -->
                 <div class="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
-                    <h3
+                    <Title
+                        level={3}
+                        variant="field"
+                        color="secondary"
                         id="funding-partners-heading"
-                        class="text-secondary text-sm font-bold sm:text-base"
                     >
                         {$t("common.footer.funding.title")}
-                    </h3>
+                    </Title>
                     <div
                         class="flex items-center gap-4"
                         role="list"
@@ -51,9 +54,9 @@
 
                 <!-- Part Of Section -->
                 <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-4">
-                    <h3 class="text-secondary text-sm font-medium sm:text-base">
+                    <Title level={3} variant="field" color="secondary" weight="medium">
                         {$t("common.footer.funding.partOf")}
-                    </h3>
+                    </Title>
                     <div
                         class="flex items-center gap-2 sm:gap-3"
                         role="list"
@@ -113,9 +116,9 @@
 
                         <!-- Collaborate -->
                         <div class="space-y-2">
-                            <h4 class="text-purple-soft text-sm leading-6 font-bold sm:text-base">
+                            <Title level={4} variant="field" color="purple-soft" class="leading-6">
                                 {$t("common.footer.navigation.collaborate.title")}
-                            </h4>
+                            </Title>
                             <ul class="space-y-1 text-xs leading-5 sm:text-sm sm:leading-6">
                                 <li>
                                     <FooterLink href="/create-project">
@@ -137,9 +140,9 @@
 
                         <!-- Help -->
                         <div class="space-y-2">
-                            <h4 class="text-purple-soft text-sm leading-6 font-bold sm:text-base">
+                            <Title level={4} variant="field" color="purple-soft" class="leading-6">
                                 {$t("common.footer.navigation.help.title")}
-                            </h4>
+                            </Title>
                             <ul class="space-y-1 text-xs leading-5 sm:text-sm sm:leading-6">
                                 <li>
                                     <FooterLink href="/faqs">
@@ -161,9 +164,9 @@
 
                         <!-- About Goteo -->
                         <div class="space-y-2">
-                            <h4 class="text-purple-soft text-sm leading-6 font-bold sm:text-base">
+                            <Title level={4} variant="field" color="purple-soft" class="leading-6">
                                 {$t("common.footer.navigation.aboutGoteo.title")}
-                            </h4>
+                            </Title>
                             <ul class="space-y-1 text-xs leading-5 sm:text-sm sm:leading-6">
                                 <li>
                                     <FooterLink href="/about">
@@ -192,9 +195,9 @@
 
                         <!-- For Users -->
                         <div class="space-y-2">
-                            <h4 class="text-purple-soft text-sm leading-6 font-bold sm:text-base">
+                            <Title level={4} variant="field" color="purple-soft" class="leading-6">
                                 {$t("common.footer.navigation.forUsers.title")}
-                            </h4>
+                            </Title>
                             <ul class="space-y-1 text-xs leading-5 sm:text-sm sm:leading-6">
                                 <li>
                                     <FooterLink href="/wallet">

--- a/src/layouts/HeaderSubmenu.svelte
+++ b/src/layouts/HeaderSubmenu.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
     import HeaderCategories from "./HeaderCategories.svelte";
     import { t } from "../i18n/store";
+    import Title from "../components/library/typography/Title.svelte";
 </script>
 
 <nav class="mt-5 mb-10 flex gap-20 px-2 md:px-6">
     <section>
-        <h2 class="mb-4 text-3xl font-bold text-black">
+        <Title level={2} variant="section" class="mb-4">
             {$t("domain.header.categories")}
-        </h2>
+        </Title>
 
         <HeaderCategories />
     </section>


### PR DESCRIPTION
# Title library component
Unified heading component for the library. Replaces raw `<h1>`–`<h6>` elements with a standardized set of visual variants taken from the Figma design system. Docs about the component are in [Outline](https://docs.platoniq.net/doc/title-library-component-IvJz2jux5I).

## Why

- The codebase had **~100 raw `<h1>`–`<h6>` elements** with **46 different class combinations** spread across **40 files**.
- Most patterns were duplicated by different developers, leading to drift (e.g. `text-2xl font-bold text-black` was sometimes `text-secondary`, sometimes `text-black`, sometimes responsive, sometimes not).
- This component enforces visual consistency, makes the design system the single source of truth, and frees developers from having to remember the right classes for each heading.

## Out-of-system cases

The following heading patterns currently exist in the codebase but do not map to any Figma variant. I was keeping them as raw `<h*>` elements until the Figma library were updated or a decision is made:

- 14px uppercase group headers (admin `Search.svelte`)
- 14px semibold labels in toast positions (`ProjectEditorShell.svelte`)

But, finally, I decided to move uppercase group headers to a different admin component called `SearchCategoryLabel.svelte` (with `<p>`) and the labels in toast positions just using them as `<span>`.

## Migration mapping

| Before (raw)                                                                          | After (`<Title>`)                                                       |
| ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| `<h1 class="text-3xl font-bold text-black lg:text-4xl">`                              | `level=1 variant=section`                                               |
| `<h1 class="text-content text-3xl font-bold lg:text-4xl">`                             | `level=1 variant=section class="text-content"`                          |
| `<h1 class="text-3xl leading-12 font-bold text-black lg:text-[2.5rem]">`              | `level=1 variant=section`                                               |
| `<h1 class="text-[2.5rem] leading-12 font-bold text-black lg:text-[2.5rem]">`        | `level=1 variant=headline`                                              |
| `<h1 class="text-[2.5rem]/12 font-bold text-black">`                                  | `level=1 variant=headline`                                              |
| `<h1 class="text-secondary text-2xl leading-tight font-bold">`                        | `level=1 variant=subsection color=secondary class="leading-tight"`      |
| `<h1 class="text-secondary text-double mb-2 leading-10 font-bold">` (preview)         | `level=2 variant=section color=secondary class="mb-2"`                 |
| `<h1 class="text-center text-3xl leading-tight font-bold text-black sm:text-6xl">`    | `level=1 variant=display align=center`                                  |
| `<h1 class="text-secondary text-[3.5rem] leading-tight font-semibold">`               | `level=2 variant=display color=secondary weight=bold class="leading-tight"` |
| `<h2 class="mb-4 text-3xl font-bold text-black">`                                     | `level=2 variant=section class="mb-4"`                                  |
| `<h2 class="text-2xl font-bold text-black">`                                          | `level=2 variant=subsection`                                            |
| `<h2 class="text-xl font-bold text-black">` (modals)                                  | `level=2 variant=subsection`                                            |
| `<h2 class="text-2xl font-bold text-black md:text-3xl">`                              | `level=2 variant=subsection`                                            |
| `<h2 class="text-3xl font-bold text-black md:text-4xl">`                              | `level=2 variant=section`                                               |
| `<h2 class="mb-1 text-2xl font-bold text-black">`                                     | `level=2 variant=subsection class="mb-1"`                               |
| `<h2 class="text-[2.5rem] leading-12 font-bold text-black">`                          | `level=2 variant=headline`                                              |
| `<h2 class="text-secondary text-2xl font-bold">`                                      | `level=2 variant=subsection color=secondary`                            |
| `<h2 class="text-secondary text-4xl font-bold">`                                      | `level=2 variant=headline color=secondary`                              |
| `<h2 class="text-secondary line-clamp-1 text-2xl">`                                   | `level=2 variant=subsection color=secondary truncate=1`                 |
| `<h2 class="text-secondary line-clamp-2 flex max-w-2xl text-4xl font-bold">`          | `level=2 variant=headline color=secondary truncate=2 class="flex max-w-2xl"` |
| `<h2 class="text-secondary text-center text-2xl font-bold lg:text-3xl">`              | `level=2 variant=subsection color=secondary align=center`               |
| `<h2 class="text-2xl font-bold tracking-tight sm:text-3xl md:text-4xl">`              | `level=2 variant=section class="tracking-tight"`                        |
| `<h2 class="text-secondary text-2xl ... md:text-[2.5rem] md:leading-12">`             | `level=2 variant=section color=secondary class="leading-tight"`         |
| `<h2 class="text-3xl leading-tight font-bold md:text-4xl" style="display:...">`       | `level=2 variant=section class="leading-tight" style="display:..."`      |
| `<h2 class="lg:text-double flex items-center gap-2 text-base font-semibold {color}">` | `level=2 variant=subsection color={secondary\|default} class="flex items-center gap-2 lg:text-double" weight="semibold"` |
| `<h2 class="text-secondary flex items-center gap-2 text-base font-semibold">`         | `level=2 variant=subsection color=secondary class="flex items-center gap-2"` |
| `<h2 class="text-secondary font-bold" + dynamicSizeStyles>`                           | `level=2 variant=subsection color=secondary class={titleStyles[type]}`  |
| `<h2 class="relative z-10 font-bold text-white" + dynamicSizeStyles>`                  | `level=2 variant=subsection color="white" class="relative z-10 {titleStyles[type]}"` |
| `<h2 class="text-purple-soft font-bold {dynamic size}">` (CreateCard)                 | `level=2 variant={subsection\|headline} color="purple-soft" class={leading}` |
| `<h3 class="text-secondary line-clamp-2 w-full text-left text-2xl font-semibold">`    | `level=3 variant=subsection color=secondary truncate=2 weight=bold class="w-full text-left"` |
| `<h3 class="text-secondary line-clamp-2 w-full text-left text-2xl font-bold">`        | `level=3 variant=subsection color=secondary truncate=2 class="w-full text-left"` |
| `<h3 class="text-secondary h-16 overflow-hidden text-2xl leading-8 font-bold">`        | `level=3 variant=subsection color=secondary class="h-16 overflow-hidden leading-8"` |
| `<h3 class="text-secondary text-lg leading-8 font-bold md:text-2xl md:leading-8">`    | `level=3 variant=subsection color=secondary`                            |
| `<h3 class="text-secondary text-3xl font-bold">` (modal)                              | `level=3 variant=section color=secondary`                               |
| `<h3 class="min-w-full text-3xl leading-tight font-bold text-white md:text-4xl lg:text-5xl">` | `level=3 variant=section color="white" class="min-w-full leading-tight"` |
| `<h3 class="text-content text-xl font-bold lg:text-2xl">` (By {owner})                | **DEMOTED to `<p>`** (caption, not heading)                             |
| `<h3 class="font-body mb-6 text-base font-bold text-black">`                          | `level=3 variant=field class="font-body mb-6"`                         |
| `<h3 class="font-body mb-2 text-base font-bold text-black">`                          | `level=3 variant=field class="font-body mb-2"`                         |
| `<h3 class="text-base font-bold text-black">`                                         | `level=3 variant=field`                                                 |
| `<h3 class="text-secondary text-sm font-semibold">` (toast)                           | `level=3 variant=subsection color="secondary" class="text-sm"`         |
| `<h3 class="text-secondary text-base font-bold">`                                     | `level=3 variant=field color=secondary`                                 |
| `<h4 class="text-purple-soft text-sm leading-6 font-bold sm:text-base">`              | `level=4 variant=field color=purple-soft class="leading-6"`            |
| `<h3 class="text-secondary text-sm font-bold sm:text-base">` (Footer h3 funding)      | `level=3 variant=field color="secondary" id="funding-partners-heading"` |
| `<h3 class="text-secondary text-sm font-medium sm:text-base">` (Footer h3 partOf)     | `level=3 variant=field color="secondary" weight="medium"`              |
| `<h2 class="text-lg font-semibold text-red-800">` (validation summary)                | **DEMOTED to `<p>`** (inside `<div role="alert">`)                     |
| `<h3 class="text-sm font-medium text-red-800">` (search error)                        | **DEMOTED to `<span>`** (followed by `<p>`)                            |
| `<h3 class="text-xl font-semibold text-gray-900">` (empty/initial state)              | **DEMOTED to `<span>`** (followed by `<p>`)                            |
| `<h3 class="text-sm font-bold text-gray-700 uppercase">` (admin Search categories)    | **NO MIGRATION** — uses `<SearchCategoryLabel>` component               |
| `<h2 class="sr-only">Footer Navigation</h2>`                                          | **NO MIGRATION** (raw `<h2>`, a11y-only)                                |
| `<h3 class="sr-only">Legal and Social Links</h3>`                                     | **NO MIGRATION** (raw `<h3>`, a11y-only)                                |
| `<h1>{post.title}</h1>` (BodyBlog)                                                    | **NO MIGRATION** (marked-content style)                                 |
| `<h3>...</h3>` (RewardModal, parent-styled)                                           | **NO MIGRATION** (parent-styled)                                        |
| `<h2>`, `<h3>` in `*.stories.svelte` files                                           | **NO MIGRATION** (Storybook examples)                                   |

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217191367616064